### PR TITLE
Fix calculation of posterior mean for beta binomial model

### DIFF
--- a/test/models/beta_binomial.py
+++ b/test/models/beta_binomial.py
@@ -3,6 +3,12 @@ from scipy import stats
 import numpy as np
 
 
+X = 5
+N = 15
+A = 2
+B = 3
+
+
 class BetaBinom:
     def dims(self) -> int:
         return 1
@@ -11,13 +17,13 @@ class BetaBinom:
         return self.log_likelihood(theta) + self.log_prior(theta)
 
     def log_prior(self, theta) -> float:
-        return stats.beta.logpdf(theta[0], 2, 3)
+        return stats.beta.logpdf(theta[0], A, B)
 
     def log_likelihood(self, theta) -> float:
-        return stats.binom.logpmf(5, 15, theta[0])
+        return stats.binom.logpmf(X, N, theta[0])
 
     def initial_state(self, _: int):
-        return stats.beta.rvs(2, 3, size=1)
+        return stats.beta.rvs(A, B, size=1)
 
     def log_density_gradient(self, theta) -> Tuple[float, np.ndarray]:
         # use finite diffs for now
@@ -26,3 +32,9 @@ class BetaBinom:
         lp = self.log_density(theta)
         lp_plus_e = self.log_density(theta + epsilon)
         return lp, np.array([(lp - lp_plus_e)])
+
+    def posterior_mean(self):
+        return (A + X) / (A + B + N)
+
+    def posterior_variance(self):
+        return ((A + X) * (B + N - X)) / ((A + B + N) ** 2 * (A + B + N + 1))

--- a/test/models/std_normal.py
+++ b/test/models/std_normal.py
@@ -6,3 +6,9 @@ class StdNormal:
 
     def log_density_gradient(self, params_unc):
         return -0.5 * params_unc[0] * params_unc[0], -params_unc
+
+    def posterior_mean(self):
+        return 0
+
+    def posterior_variance(self):
+        return 1

--- a/test/test_hmc.py
+++ b/test/test_hmc.py
@@ -2,17 +2,18 @@ from models.std_normal import StdNormal
 from bayes_kit.hmc import HMCDiag
 import numpy as np
 
+
 def test_hmc_diag():
     # init with draw from posterior
     init = np.random.normal(loc=0, scale=1, size=[1])
     model = StdNormal()
-    mala = HMCDiag(model, steps=10, stepsize=0.25, init=init)
+    hmc = HMCDiag(model, steps=10, stepsize=0.25, init=init)
 
     M = 10000
-    draws = np.array([mala.sample()[0] for _ in range(M)])
+    draws = np.array([hmc.sample()[0] for _ in range(M)])
 
     mean = draws.mean(axis=0)
     var = draws.var(axis=0, ddof=1)
 
-    np.testing.assert_allclose(mean, 0, atol=0.1)
-    np.testing.assert_allclose(var, 1, atol=0.1)
+    np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.1)
+    np.testing.assert_allclose(var, model.posterior_variance(), atol=0.1)

--- a/test/test_mala.py
+++ b/test/test_mala.py
@@ -16,8 +16,8 @@ def test_mala_std_normal():
     mean = draws.mean(axis=0)
     var = draws.var(axis=0, ddof=1)
 
-    np.testing.assert_allclose(mean, 0, atol=0.1)
-    np.testing.assert_allclose(var, 1, atol=0.1)
+    np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.1)
+    np.testing.assert_allclose(var, model.posterior_variance(), atol=0.1)
 
 
 def test_mala_beta_binom():
@@ -33,5 +33,5 @@ def test_mala_beta_binom():
     print(f"{draws[1:10]=}")
     print(f"{mean=}  {var=}")
 
-    np.testing.assert_allclose(mean, 7 / 25, atol=0.1)
-    np.testing.assert_allclose(var, 7 * 18 / (25**2 * 26), atol=0.1)
+    np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.03)
+    np.testing.assert_allclose(var, model.posterior_variance(), atol=0.005)

--- a/test/test_rwm.py
+++ b/test/test_rwm.py
@@ -12,8 +12,8 @@ def test_rwm():
     draws = np.array([rwm.sample()[0] for _ in range(M)])
     mean = draws.mean(axis=0)
     var = draws.var(axis=0, ddof=1)
-    np.testing.assert_allclose(mean, 0, atol=0.1)
-    np.testing.assert_allclose(var, 1, atol=0.1)
+    np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.1)
+    np.testing.assert_allclose(var, model.posterior_variance(), atol=0.1)
 
     accept = M - (draws[:M-1] == draws[1:]).sum()
     print(f"{accept=}")

--- a/test/test_tempered_smc.py
+++ b/test/test_tempered_smc.py
@@ -25,5 +25,5 @@ def test_rwm_smc():
     print(f"{draws[1:10]=}")
     print(f"{mean=}  {var=}")
 
-    np.testing.assert_allclose(mean, 7 / 25, atol=0.1)
-    np.testing.assert_allclose(var, 7 * 18 / (25**2 * 26), atol=0.1)
+    np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.03)
+    np.testing.assert_allclose(var, model.posterior_variance(), atol=0.005)


### PR DESCRIPTION
Closes #5 

We had the wrong answer for the mean in our tests (0.28 vs 0.35) and a tolerance _just_ wide enough that it often passed this anyway. This should make the tests _much_ stabler. 

By moving the `posterior_mean` and `posterior_variance` into the test models themselves we also get closer to writing generic testing code.