### PR TITLE
Add seed arguments to objects which need randomness

### DIFF
--- a/bayes_kit/model_types.py
+++ b/bayes_kit/model_types.py
@@ -6,22 +6,22 @@ import numpy as np
 class LogDensityModel(Protocol):
     def dims(self) -> int:
         """number of parameters"""
-        ...
+        ...  # pragma: no cover
 
     def log_density(self, params_unc: NDArray[np.float64]) -> float:
         """unnormalized log density"""
-        ...
+        ...  # pragma: no cover
 
 
 class GradModel(LogDensityModel, Protocol):
     def log_density_gradient(
         self, params_unc: NDArray[np.float64]
     ) -> Tuple[float, ArrayLike]:
-        ...
+        ...  # pragma: no cover
 
 
 class HessianModel(GradModel, Protocol):
     def log_density_hessian(
         self, params_unc: NDArray[np.float64]
     ) -> Tuple[float, ArrayLike, ArrayLike]:
-        ...
+        ...  # pragma: no cover

--- a/bayes_kit/smc.py
+++ b/bayes_kit/smc.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterator
+from typing import Callable, Iterator, Union
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
@@ -55,6 +55,7 @@ class TemperedLikelihoodSMC:
         self.thetas = importance_resample(self.thetas, lpminus1, lp)
 
 
+# TODO(bward): factor out
 def importance_resample(
     thetas: Vector, lpminus1: DensityFunction, lp: DensityFunction
 ) -> Vector:
@@ -62,13 +63,14 @@ def importance_resample(
         np.apply_along_axis(lp, axis=1, arr=thetas)
         - np.apply_along_axis(lpminus1, axis=1, arr=thetas)
     )
-    # note: should use random Generator object
     M = thetas.shape[0]
+    # TODO(bward): should use random Generator object
     idxs = np.random.choice(M, size=M, replace=True, p=weights / weights.sum())
 
-    return thetas[idxs] # type: ignore
+    return thetas[idxs]  # type: ignore
 
 
+# TODO(bward): factor out/reuse Metropolis sampler
 def metropolis_kernel(scale: float) -> Kernel:
     def proposal_rng(theta: Vector) -> Vector:
         return np.random.normal(loc=theta, scale=scale)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ url=https://github.com/flatironinstitute/bayes-kit
 [options]
 python_requires = >=3.9
 install_requires =
-    numpy
+    numpy>=1.17.0
 packages = find:
 
 [options.extras_require]

--- a/test/models/beta_binomial.py
+++ b/test/models/beta_binomial.py
@@ -1,16 +1,24 @@
-from typing import Tuple
+from typing import Union
 from scipy import stats
 import numpy as np
 import numpy.typing as npt
 
 
-X = 5
-N = 15
-A = 2
-B = 3
-
-
 class BetaBinom:
+    def __init__(
+        self,
+        alpha: float = 2,
+        beta: float = 3,
+        x: int = 5,
+        N: int = 15,
+        seed: Union[None, int, np.random.BitGenerator, np.random.Generator] = None,
+    ) -> None:
+        self.alpha = alpha
+        self.beta = beta
+        self.x = x
+        self.N = N
+        self._rand = np.random.default_rng(seed)
+
     def dims(self) -> int:
         return 1
 
@@ -18,15 +26,17 @@ class BetaBinom:
         return self.log_likelihood(theta) + self.log_prior(theta)
 
     def log_prior(self, theta: npt.NDArray[np.float64]) -> float:
-        return stats.beta.logpdf(theta[0], A, B)
+        return stats.beta.logpdf(theta[0], self.alpha, self.beta)
 
     def log_likelihood(self, theta: npt.NDArray[np.float64]) -> float:
-        return stats.binom.logpmf(X, N, theta[0])
+        return stats.binom.logpmf(self.x, self.N, theta[0])
 
     def initial_state(self, _: int) -> npt.NDArray[np.float64]:
-        return stats.beta.rvs(A, B, size=1)
+        return self._rand.beta(self.alpha, self.beta, size=1)
 
-    def log_density_gradient(self, theta: npt.NDArray[np.float64]) -> tuple[float, npt.NDArray[np.float64]]:
+    def log_density_gradient(
+        self, theta: npt.NDArray[np.float64]
+    ) -> tuple[float, npt.NDArray[np.float64]]:
         # use finite diffs for now
         epsilon = 0.000001
 
@@ -35,7 +45,10 @@ class BetaBinom:
         return lp, np.array([(lp - lp_plus_e)])
 
     def posterior_mean(self) -> float:
-        return (A + X) / (A + B + N)
+        return (self.alpha + self.x) / (self.alpha + self.beta + self.N)
 
     def posterior_variance(self) -> float:
-        return ((A + X) * (B + N - X)) / ((A + B + N) ** 2 * (A + B + N + 1))
+        return ((self.alpha + self.x) * (self.beta + self.N - self.x)) / (
+            (self.alpha + self.beta + self.N) ** 2
+            * (self.alpha + self.beta + self.N + 1)
+        )

--- a/test/test_hmc.py
+++ b/test/test_hmc.py
@@ -3,7 +3,7 @@ from bayes_kit.hmc import HMCDiag
 import numpy as np
 
 
-def test_hmc_diag() -> None:
+def test_hmc_diag_std_normal() -> None:
     # init with draw from posterior
     init = np.random.normal(loc=0, scale=1, size=[1])
     model = StdNormal()
@@ -17,3 +17,16 @@ def test_hmc_diag() -> None:
 
     np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.1)
     np.testing.assert_allclose(var, model.posterior_variance(), atol=0.1)
+
+def test_hmc_diag_repr() -> None:
+    init = np.random.normal(loc=0, scale=1, size=[1])
+    model = StdNormal()
+
+    hmc_1 = HMCDiag(model, steps=10, stepsize=0.25, init=init, seed=123)
+    hmc_2 = HMCDiag(model, steps=10, stepsize=0.25, init=init, seed=123)
+
+    M = 25
+    draws_1 = np.array([hmc_1.sample()[0] for _ in range(M)])
+    draws_2 = np.array([hmc_2.sample()[0] for _ in range(M)])
+
+    np.testing.assert_array_equal(draws_1, draws_2)

--- a/test/test_mala.py
+++ b/test/test_mala.py
@@ -35,3 +35,17 @@ def test_mala_beta_binom() -> None:
 
     np.testing.assert_allclose(mean, model.posterior_mean(), atol=0.05)
     np.testing.assert_allclose(var, model.posterior_variance(), atol=0.005)
+
+
+def test_mala_repr() -> None:
+    init = np.random.normal(loc=0, scale=1, size=[1])
+    model = StdNormal()
+
+    mala_1 = MALA(model, 0.3, init, seed=123)
+    mala_2 = MALA(model, 0.3, init, seed=123)
+
+    M = 25
+    draws_1 = np.array([mala_1.sample()[0] for _ in range(M)])
+    draws_2 = np.array([mala_2.sample()[0] for _ in range(M)])
+
+    np.testing.assert_array_equal(draws_1, draws_2)

--- a/test/test_rwm.py
+++ b/test/test_rwm.py
@@ -2,7 +2,7 @@ from test.models.std_normal import StdNormal
 from bayes_kit.rwm import RandomWalkMetropolis
 import numpy as np
 
-def test_rwm() -> None:
+def test_rwm_std_normal() -> None:
     # init with draw from posterior
     init = np.random.normal(loc=0, scale=1, size=[1])
     model = StdNormal()
@@ -21,3 +21,21 @@ def test_rwm() -> None:
     print(f"{mean=}  {var=}")
 
 
+def test_rwm_repr() -> None:
+
+    init = np.random.normal(loc=0, scale=1, size=[1])
+    model = StdNormal()
+
+    prop_gen_1 = np.random.default_rng(123)
+    proposal_1 = lambda theta: prop_gen_1.normal(loc=theta, scale=4)
+    rwm_1 = RandomWalkMetropolis(model, proposal_1, init, seed=456)
+
+    prop_gen_2 = np.random.default_rng(123)
+    proposal_2 = lambda theta: prop_gen_2.normal(loc=theta, scale=4)
+    rwm_2 = RandomWalkMetropolis(model, proposal_2, init, seed=456)
+
+    M = 25
+    draws_1 = np.array([rwm_1.sample()[0] for _ in range(M)])
+    draws_2 = np.array([rwm_2.sample()[0] for _ in range(M)])
+
+    np.testing.assert_array_equal(draws_1, draws_2)

--- a/test/test_tempered_smc.py
+++ b/test/test_tempered_smc.py
@@ -3,7 +3,7 @@ from bayes_kit.smc import TemperedLikelihoodSMC, metropolis_kernel
 import numpy as np
 
 
-def test_rwm_smc():
+def test_rwm_smc_beta_binom():
     model = BetaBinom()
     M = 75
     N = 10


### PR DESCRIPTION
This uses numpy's recommendation of [`np.random.default_rng(seed)`](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng). If this is fed `None` (our default), it is random each run, but it can be given an integer or an instance of the `Generator` class, which it just returns untouched. 