### PR TITLE
Fixing 'init or' syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm project settings
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/bayes_kit/ensemble.py
+++ b/bayes_kit/ensemble.py
@@ -33,7 +33,7 @@ class Stretcher:
     #     self._drawshape = (self._walkers, self._dim)
     #     if init != None and init.shape != self._drawshape:
     #         raise ValueError(f"init must be shape of draw {self._drawshape}; found {init.shape=}")
-    #     self._thetas = init or np.random.normal(size=self._drawshape)
+    #     self._thetas = init if init is not None else np.random.normal(size=self._drawshape)
     #     self._firsthalf = range(halfwalkers)
     #     self._secondhalf = range(halfwalkers, walkers)
 

--- a/bayes_kit/hmc.py
+++ b/bayes_kit/hmc.py
@@ -23,7 +23,11 @@ class HMCDiag:
         self._steps = steps
         self._metric = metric_diag or np.ones(self._dim)
         self._rng = np.random.default_rng(seed)
-        self._theta = init if init is not None else self._rng.normal(size=self._dim)
+        self._theta = (
+            init
+            if (init is not None and init.shape != (0,))
+            else self._rng.normal(size=self._dim)
+        )
 
     def __iter__(self) -> Iterator[Draw]:
         return self

--- a/bayes_kit/hmc.py
+++ b/bayes_kit/hmc.py
@@ -23,7 +23,7 @@ class HMCDiag:
         self._steps = steps
         self._metric = metric_diag or np.ones(self._dim)
         self._rng = np.random.default_rng(seed)
-        self._theta = init or self._rng.normal(size=self._dim)
+        self._theta = init if init is not None else self._rng.normal(size=self._dim)
 
     def __iter__(self) -> Iterator[Draw]:
         return self

--- a/bayes_kit/mala.py
+++ b/bayes_kit/mala.py
@@ -25,7 +25,7 @@ class MALA:
         self._epsilon = epsilon
         self._dim = self._model.dims()
         self._rng = np.random.default_rng(seed)
-        self._theta = init or self._rng.normal(size=self._dim)
+        self._theta = init if init is not None else self._rng.normal(size=self._dim)
         self._log_p_theta, logpgrad = self._model.log_density_gradient(self._theta)
         self._log_p_grad_theta = np.asanyarray(logpgrad)
 

--- a/bayes_kit/mala.py
+++ b/bayes_kit/mala.py
@@ -25,7 +25,11 @@ class MALA:
         self._epsilon = epsilon
         self._dim = self._model.dims()
         self._rng = np.random.default_rng(seed)
-        self._theta = init if init is not None else self._rng.normal(size=self._dim)
+        self._theta = (
+            init
+            if (init is not None and init.shape != (0,))
+            else self._rng.normal(size=self._dim)
+        )
         self._log_p_theta, logpgrad = self._model.log_density_gradient(self._theta)
         self._log_p_grad_theta = np.asanyarray(logpgrad)
 

--- a/bayes_kit/metropolis.py
+++ b/bayes_kit/metropolis.py
@@ -94,7 +94,7 @@ class MetropolisHastings:
         self._rng = np.random.default_rng(seed)
         self._proposal_fn = proposal_fn
         self._transition_lp_fn = transition_lp_fn
-        self._theta = init or self._rng.normal(size=self._dim)
+        self._theta = init if init is not None else self._rng.normal(size=self._dim)
         self._log_p_theta = self._model.log_density(self._theta)
 
     def __iter__(self) -> Iterator[Draw]:

--- a/bayes_kit/metropolis.py
+++ b/bayes_kit/metropolis.py
@@ -94,7 +94,11 @@ class MetropolisHastings:
         self._rng = np.random.default_rng(seed)
         self._proposal_fn = proposal_fn
         self._transition_lp_fn = transition_lp_fn
-        self._theta = init if init is not None else self._rng.normal(size=self._dim)
+        self._theta = (
+            init
+            if (init is not None and init.shape != (0,))
+            else self._rng.normal(size=self._dim)
+        )
         self._log_p_theta = self._model.log_density(self._theta)
 
     def __iter__(self) -> Iterator[Draw]:

--- a/test/test_theta_initialization.py
+++ b/test/test_theta_initialization.py
@@ -1,0 +1,53 @@
+import numpy as np
+from numpy.typing import NDArray
+from unittest.mock import Mock
+
+from bayes_kit.hmc import HMCDiag
+from bayes_kit.mala import MALA
+from bayes_kit.metropolis import Metropolis, MetropolisHastings
+from bayes_kit.model_types import HessianModel
+
+
+def assert_not_empty_array(a: NDArray[np.float64]):
+    with np.testing.assert_raises(AssertionError):
+        np.testing.assert_array_equal(a, np.array([]))
+
+
+def make_models(init: NDArray[np.float64], dims: int = 1):
+    # For the purposes of this (and future) tests, we only care about the model's dimensions.
+    mock_model: HessianModel = Mock()
+    mock_model.dims = Mock(return_value=dims)
+    mock_model.log_density_gradient = Mock(return_value=(0.5, (0,)))
+    mock_model.log_density_hessian = Mock(return_value=(0, 5, (0,), (0,)))
+
+    # TODO: Add ensemble/stretcher once the class is available
+    hmc = HMCDiag(mock_model, stepsize=0.25, steps=10, init=init)
+    mala = MALA(mock_model, epsilon=0.5, init=init)
+    metro = Metropolis(mock_model, lambda x: 1, init=init)
+    mh = MetropolisHastings(mock_model, lambda x: 1, lambda x, y: 1, init=init)
+    # TemperedLikelihoodSMC omitted since it does not have explicit-value initialization of thetas
+
+    return [hmc, mala, metro, mh]
+
+
+def test_init_with_empty_numpy_array() -> None:
+    # an "empty" initialization should be treated as no initialization
+    # (i.e. not honored)
+    init = np.array([])
+    models = make_models(init)
+    for model in models:
+        assert_not_empty_array(model._theta)
+
+
+def test_init_with_one_element_numpy_array() -> None:
+    init = np.array([3])
+    models = make_models(init)
+    for model in models:
+        np.testing.assert_array_equal(model._theta, init)
+
+
+def test_init_with_multi_element_numpy_array() -> None:
+    init = np.array([3, 3, 3])
+    models = make_models(init, dims=3)
+    for model in models:
+        np.testing.assert_array_equal(model._theta, init)


### PR DESCRIPTION
Using `self._thetas = init or np.random.normal(...)` fails when `init` is given as a numpy array. This change makes an explicit check for `None` instead.