### PR TITLE
More efficient HMCDiag.leapfrog 

### DIFF
--- a/test/test_hmc.py
+++ b/test/test_hmc.py
@@ -3,6 +3,7 @@ from test.models.std_normal import StdNormal
 from bayes_kit.hmc import HMCDiag
 import numpy as np
 import functools
+import pytest
 
 
 def _call_counter(f):
@@ -15,13 +16,14 @@ def _call_counter(f):
     return wrapper
 
 
-def test_hmc_leapfrog_num_evals() -> None:
+@pytest.mark.parametrize("steps", [0, 1, 10])
+def test_hmc_leapfrog_num_evals(steps) -> None:
     # Expect that HMC.leapfrog calls log_density only once per step
     model = StdNormal()
     model.log_density = _call_counter(model.log_density)
     model.log_density_gradient = _call_counter(model.log_density_gradient)
 
-    hmc = HMCDiag(model, steps=10, stepsize=0.25)
+    hmc = HMCDiag(model, steps=steps, stepsize=0.25)
     _ = hmc.sample()
 
     # Expect one call to log_density before leapfrog and one after

--- a/test/test_hmc.py
+++ b/test/test_hmc.py
@@ -2,6 +2,32 @@ from test.models.binomial import Binomial
 from test.models.std_normal import StdNormal
 from bayes_kit.hmc import HMCDiag
 import numpy as np
+import functools
+
+
+def _call_counter(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        wrapper.calls += 1
+        return f(*args, **kwargs)
+
+    wrapper.calls = 0
+    return wrapper
+
+
+def test_hmc_leapfrog_num_evals() -> None:
+    # Expect that HMC.leapfrog calls log_density only once per step
+    model = StdNormal()
+    model.log_density = _call_counter(model.log_density)
+    model.log_density_gradient = _call_counter(model.log_density_gradient)
+
+    hmc = HMCDiag(model, steps=10, stepsize=0.25)
+    _ = hmc.sample()
+
+    # Expect one call to log_density before leapfrog and one after
+    assert model.log_density.calls == 2
+    # Expect one call to log_density_gradient per leapfrog step, plus one for initial/final half step
+    assert model.log_density_gradient.calls == hmc._steps + 1
 
 
 def test_hmc_diag_std_normal() -> None:


### PR DESCRIPTION
Inside `HMCDiag.leapfrog()`, this moves the half momentum steps outside the loop.

In the spirit of TDD, added a test that asserts that the number of calls to `model.log_density_gradient` is equal to `hmc._steps + 1`, where before it was `2 * hmc._steps`.