### PR TITLE
Make tests deterministic from seed

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,8 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_test_seed():
+    # Set the random seed before each test. Seed chosen by keyboard-mashing.
+    np.random.seed(246784289)


### PR DESCRIPTION
Add conftest.py and use it to set a random seed for all pytest tests.

This PR makes pytest deterministic and solves the problem of tests randomly failing due to unlucky RNG. There are pros and cons to this, of course. I find that it tends to help in CI settings.