### PR TITLE
Using LogPriorLikelihoodModel as subtype of LogDensityModel in SMC

### DIFF
--- a/bayes_kit/model_types.py
+++ b/bayes_kit/model_types.py
@@ -25,3 +25,11 @@ class HessianModel(GradModel, Protocol):
         self, params_unc: NDArray[np.float64]
     ) -> Tuple[float, ArrayLike, ArrayLike]:
         ...  # pragma: no cover
+
+
+class LogPriorLikelihoodModel(LogDensityModel, Protocol):
+    def log_prior(self, params_unc: NDArray[np.float64]) -> float:
+        ...  # pragma: no cover
+
+    def log_likelihood(self, params_unc: NDArray[np.float64]) -> float:
+        ...  # pragma: no cover

--- a/test/test_tempered_smc.py
+++ b/test/test_tempered_smc.py
@@ -8,11 +8,10 @@ def test_rwm_smc_binom() -> None:
     M = 75
     N = 15
     rwm_smc = TemperedLikelihoodSMC(
+        model,
         M,
         N,
         model.initial_state,
-        model.log_likelihood,
-        model.log_prior,
         metropolis_kernel(0.5),
     )
 


### PR DESCRIPTION
This just lets SMC use an interface consistent with other inference algorithms. Setting up a much larger upcoming PR proposing various `Protocol`s and base classes.